### PR TITLE
Updated body regexs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 const interfaceNameRegex = /(interface|class) ([a-zA-Z0-9?]+) /g;
-const interfaceBodyRegex = /((interface|class) [a-zA-Z0-9?]+\s{[\sa-zA-Z:?;\[\]]+})/g;
-const interfaceBodyExportsOnlyRegex = /(export (interface|class) [a-zA-Z0-9?]+\s{[\sa-zA-Z:?;\[\]]+})/g;
+const interfaceBodyRegex = /((interface|class) [a-zA-Z0-9?]+\s*{[\sa-zA-Z:?;\[\]]+})/g;
+const interfaceBodyExportsOnlyRegex = /(export (interface|class) [a-zA-Z0-9?]+\s*{[\sa-zA-Z:?;\[\]]+})/g;
 const propertyRegex = /([a-zA-Z0-9?]+\s*:\s*[a-zA-Z\[\]]+)/g;
 
 export interface TsProperty {


### PR DESCRIPTION
- to include 0 or more spaces between interface/class and openning {, previously this required at least 1 space.
- Ran tests, all passing.

This is a fix for issue I created here https://github.com/Box-Of-Hats/ts-csharp/issues/6